### PR TITLE
using link to master until npm registry publishes 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "pkginfo": "0.2.3",
     "underscore": "1.3.3",
-    "iron_core": ">=0.2.3"
+    "iron_core": "git://github.com/iron-io/iron_core_node#master"
   },
   "devDependencies": {
     "coffee-script": "1.6.2"


### PR DESCRIPTION
This library is broken without using iron_core 0.2.4, but the NPM registry doesn't see 0.2.4 (though the master branch of iron_core has version=0.2.4). This is a temporary fix until 0.2.4 is published.
